### PR TITLE
Flush once

### DIFF
--- a/broadcast/broadcast.go
+++ b/broadcast/broadcast.go
@@ -1,29 +1,64 @@
 package broadcast
 
-import "github.com/bitly/go-nsq"
+import (
+	"time"
+
+	"github.com/bitly/go-nsq"
+	"github.com/garyburd/redigo/redis"
+	"github.com/segmentio/go-log"
+	"github.com/statsd/client"
+)
+
+// Handler is a message handler.
+type Handler interface {
+	Handle(*Conn, *nsq.Message) error
+}
+
+// Options for broadcast.
+type Options struct {
+	Redis   *redis.Pool
+	Metrics *statsd.Client
+	Log     *log.Logger
+}
 
 // Broadcast consumer distributes messages to N handlers.
 type Broadcast struct {
-	handlers []nsq.Handler
+	handlers []Handler
+	*Options
 }
 
 // New broadcast consumer.
-func New() *Broadcast {
-	return new(Broadcast)
+func New(o *Options) *Broadcast {
+	return &Broadcast{Options: o}
 }
 
 // Add handler.
-func (b *Broadcast) Add(h nsq.Handler) {
+func (b *Broadcast) Add(h Handler) {
 	b.handlers = append(b.handlers, h)
 }
 
 // HandleMessage parses distributes messages to each delegate.
 func (b *Broadcast) HandleMessage(msg *nsq.Message) error {
+	start := time.Now()
+	db := b.Redis.Get()
+	defer db.Close()
+
+	conn := newConn(db)
+
 	for _, h := range b.handlers {
-		err := h.HandleMessage(msg)
+		err := h.Handle(conn, msg)
 		if err != nil {
 			return err
 		}
 	}
+
+	err := conn.Flush()
+	if err != nil {
+		b.Metrics.Incr("errors.flush")
+		b.Log.Error("flush: %s", err)
+		return err
+	}
+
+	b.Metrics.Duration("timers.broadcast", time.Since(start))
 	return nil
 }

--- a/broadcast/conn.go
+++ b/broadcast/conn.go
@@ -1,0 +1,40 @@
+package broadcast
+
+import "github.com/garyburd/redigo/redis"
+
+// Conn is a single threaded
+// buffer for redis commands.
+type Conn struct {
+	conn    redis.Conn
+	pending int
+}
+
+// newConn returns a new Conn.
+func newConn(c redis.Conn) *Conn {
+	return &Conn{conn: c}
+}
+
+// Send sends the given command.
+func (c *Conn) Send(cmd string, args ...interface{}) error {
+	err := c.conn.Send(cmd, args...)
+	c.pending++
+	return err
+}
+
+// Flush will flush the redis buffers
+// and receive all responses from redis.
+func (c *Conn) Flush() error {
+	err := c.conn.Flush()
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < c.pending; i++ {
+		_, err := c.conn.Receive()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -76,9 +76,6 @@ func main() {
 	}
 	metrics.Prefix(args["--statsd-prefix"].(string))
 
-	broadcast := broadcast.New()
-	config := config(args)
-
 	idleTimeout, err := time.ParseDuration(args["--idle-timeout"].(string))
 	if err != nil {
 		log.Fatalf("error parsing idle timeout: %s", err)
@@ -100,6 +97,13 @@ func main() {
 		TestOnBorrow: ping,
 	}
 
+	broadcast := broadcast.New(&broadcast.Options{
+		Redis:   pool,
+		Metrics: metrics,
+		Log:     log.Log,
+	})
+	config := config(args)
+
 	consumer, err := nsq.NewConsumer(topic, channel, config)
 	if err != nil {
 		log.Fatalf("error starting consumer: %s", err)
@@ -112,7 +116,6 @@ func main() {
 		log.Info("publishing to %q", format)
 		pubsub, err := pubsub.New(&pubsub.Options{
 			Format:  format,
-			Redis:   pool,
 			Log:     log.Log,
 			Metrics: metrics,
 		})
@@ -134,7 +137,6 @@ func main() {
 		log.Info("listing to %q (size=%d)", format, size)
 		list, err := list.New(&list.Options{
 			Format:  format,
-			Redis:   pool,
 			Log:     log.Log,
 			Metrics: metrics,
 			Size:    20,


### PR DESCRIPTION
Previously we would acquire a redis connection for each writer, even though they handle the same message, this change will buffer writes and flush once for each message.

This will also allow us to do all sorts of things in a single place, like rate limiting and more aggressive buffering. 
