### PR TITLE
Ratelimit

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -47,7 +47,6 @@ func New(options *Options) (*List, error) {
 // applies them against the key template to produce a
 // key name, and writes to the list.
 func (l *List) Handle(c *broadcast.Conn, msg *broadcast.Message) error {
-	var v interface{}
 	start := time.Now()
 
 	key, err := l.template.Eval(msg.JSON)

--- a/list/list.go
+++ b/list/list.go
@@ -1,10 +1,8 @@
 package list
 
 import (
-	"encoding/json"
 	"time"
 
-	"github.com/bitly/go-nsq"
 	"github.com/segmentio/go-interpolate"
 	"github.com/segmentio/go-log"
 	"github.com/segmentio/go-stats"
@@ -48,17 +46,11 @@ func New(options *Options) (*List, error) {
 // HandleMessage parses json messages received from NSQ,
 // applies them against the key template to produce a
 // key name, and writes to the list.
-func (l *List) Handle(c *broadcast.Conn, msg *nsq.Message) error {
+func (l *List) Handle(c *broadcast.Conn, msg *broadcast.Message) error {
 	var v interface{}
 	start := time.Now()
 
-	err := json.Unmarshal(msg.Body, &v)
-	if err != nil {
-		l.Log.Error("parsing json: %s", err)
-		return nil
-	}
-
-	key, err := l.template.Eval(v)
+	key, err := l.template.Eval(msg.JSON)
 	if err != nil {
 		l.Log.Error("evaluating template: %s", err)
 		return nil

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/bitly/go-nsq"
 	"github.com/segmentio/go-interpolate"
 	"github.com/segmentio/go-log"
 	"github.com/segmentio/go-stats"
@@ -47,7 +46,7 @@ func New(options *Options) (*PubSub, error) {
 // Handle parses json messages received from NSQ,
 // applies them against the publish channel template to
 // produce the channel name, and then publishes to Redis.
-func (p *PubSub) Handle(c *broadcast.Conn, msg *nsq.Message) error {
+func (p *PubSub) Handle(c *broadcast.Conn, msg *broadcast.Message) error {
 	var v interface{}
 	start := time.Now()
 

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,0 +1,39 @@
+package ratelimit
+
+import (
+	"github.com/hashicorp/golang-lru"
+	"github.com/juju/ratelimit"
+)
+
+// Ratelimiter implements a simple rate limiter.
+type Ratelimiter struct {
+	keys *lru.Cache
+	rate int64
+}
+
+// New initializes a new Ratelimiter
+// with rate per second and lru key cache size.
+func New(rate, size int) *Ratelimiter {
+	c, _ := lru.New(size)
+	return &Ratelimiter{
+		keys: c,
+		rate: int64(rate),
+	}
+}
+
+// Exceeded returns true if the given `key`
+// has exceeded rate per second.
+func (rl *Ratelimiter) Exceeded(key string) bool {
+	if b, ok := rl.keys.Get(key); ok {
+		b := b.(*ratelimit.Bucket)
+		_, took := b.TakeMaxDuration(1, 0)
+		return !took
+	}
+
+	rate := float64(rl.rate)
+	cap := rl.rate
+	b := ratelimit.NewBucketWithRate(rate, cap)
+	rl.keys.Add(key, b)
+	b.Take(1)
+	return false
+}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -1,0 +1,24 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestExceeded(t *testing.T) {
+	rl := New(1, 500)
+	assert.Equal(t, rl.Exceeded("some-key"), false)
+	assert.Equal(t, rl.Exceeded("some-key"), true)
+	time.Sleep(time.Second) // :(
+	assert.Equal(t, rl.Exceeded("some-key"), false)
+	assert.Equal(t, rl.Exceeded("some-key"), true)
+}
+
+func TestMaxKeys(t *testing.T) {
+	rl := New(1, 1)
+	rl.Exceeded("a")
+	rl.Exceeded("b")
+	assert.Equal(t, rl.keys.Len(), 1)
+}


### PR DESCRIPTION
The ratelimit is totally optional, only if `--ratelimit-max-rate > 0`, so it's backwards compatible.

``` bash
 go run main.go \
  --topic reqs \
  --nsqd-tcp-address :4150 \
  --publish "pubsub:{api_key}" \
  --list "list:{api_key}" \
  --ratelimit-key api_key \
  --ratelimit-max-rate 100 \
  --level warning
```

``` bash
echo '{ "api_key":"some-api-key" }' \
  | phony --tick 1ms \
  | json_to_nsq --topic reqs --nsqd-tcp-address :4150
```

Sample output:

``` bash
  # (nsq_to_redis --ratelimit-max-rate 100)
  stats 2016/01/28 15:36:23 pushed 100.00/s (7,725)
  stats 2016/01/28 15:36:23 –––
  stats 2016/01/28 15:36:23 published 100.00/s (7,725)
  stats 2016/01/28 15:36:23 –––
  stats 2016/01/28 15:36:23 ratelimit.discard 899.76/s (99,533)
```

``` bash
  # (json_to_nsq)
  2016/01/28 15:36:48 stats: messages.published 1000.11/s (44,993)
```

@calvinfo
