### PR TITLE
Add tests for pubsub package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/*/
+nsq_to_redis

--- a/broadcast/broadcast.go
+++ b/broadcast/broadcast.go
@@ -80,7 +80,7 @@ func (b *Broadcast) HandleMessage(msg *nsq.Message) error {
 
 	db := b.Redis.Get()
 	defer db.Close()
-	conn := newConn(db)
+	conn := NewConn(db)
 
 	for _, h := range b.handlers {
 		err := h.Handle(conn, m)

--- a/broadcast/conn.go
+++ b/broadcast/conn.go
@@ -9,8 +9,8 @@ type Conn struct {
 	pending int
 }
 
-// newConn returns a new Conn.
-func newConn(c redis.Conn) *Conn {
+// NewConn returns a new Conn.
+func NewConn(c redis.Conn) *Conn {
 	return &Conn{conn: c}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+
+redis:
+  image: redis
+  ports:
+    - "6379:6379"

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -1,0 +1,80 @@
+package pubsub
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	nsq "github.com/bitly/go-nsq"
+	"github.com/bmizerany/assert"
+	"github.com/garyburd/redigo/redis"
+	"github.com/segmentio/go-log"
+	"github.com/segmentio/nsq_to_redis/broadcast"
+	statsd "github.com/statsd/client"
+)
+
+func TestPubSub(t *testing.T) {
+	pubSub, err := New(&Options{
+		Format:  "stream:project:{projectId}:ingress",
+		Log:     log.Log.New("pubsub_test"),
+		Metrics: statsd.NewClient(ioutil.Discard),
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	cPublish, err := redis.Dial("tcp", ":6379")
+	if err != nil {
+		t.Error(err)
+	}
+	defer cPublish.Close()
+
+	b := broadcast.NewConn(cPublish)
+	broadcastMessage, err := newMessage("nsq__message__id", `{"projectId":"gy2d"}`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	cSubscribe, err := redis.Dial("tcp", ":6379")
+	if err != nil {
+		t.Error(err)
+	}
+	defer cSubscribe.Close()
+	psc := redis.PubSubConn{Conn: cSubscribe}
+	psc.Subscribe("stream:project:gy2d:ingress")
+	defer psc.Close()
+
+	msgC := make(chan redis.Message, 10)
+	go func() {
+		for {
+			switch v := psc.Receive().(type) {
+			case redis.Message:
+				msgC <- v
+			}
+		}
+	}()
+
+	pubSub.Handle(b, broadcastMessage)
+	b.Flush()
+
+	msg := <-msgC
+	assert.Equal(t, "stream:project:gy2d:ingress", msg.Channel)
+	// todo(prateek): compare the JSON not the bytes.
+	assert.Equal(t, `[123 34 112 114 111 106 101 99 116 73 100 34 58 34 103 121 50 100 34 125]`, string(msg.Data))
+}
+
+func newMessage(id, contents string) (*broadcast.Message, error) {
+	var body json.RawMessage
+	err := json.Unmarshal([]byte(contents), &body)
+	if err != nil {
+		return nil, err
+	}
+
+	nsqId := [nsq.MsgIDLength]byte{}
+	copy(nsqId[:], id[:nsq.MsgIDLength])
+
+	return &broadcast.Message{
+		ID:   nsqId,
+		Body: body,
+	}, nil
+}


### PR DESCRIPTION

The only change in current code is that `broadcast.newConn` is now
exposed so we can use it in tests.


Adds a docker compose file so we can easily run tests against a real
redis instance.