### PR TITLE
Speed up JSON parsing

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -1,0 +1,95 @@
+// Package template provides a simple templating functionality.
+// Given a template in the format "foo:{bar}" and data `{"bar":"b"}`,
+// eval returns "foo:b".
+// It allows multiple variables to be supplied. Given the format "{foo}:{bar}"
+// and data `{"foo": "f", "bar": b}`, eval returns "f:b".
+// It allows nested variables. Given the format "foo:{bar.baz}" and data
+// and data `{"bar": { "baz" : "b"}}`, eval returns "foo:b".
+package template
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/tidwall/gjson"
+)
+
+var ErrMissingClosingBrace = errors.New("missing '}'")
+
+type T struct {
+	nodes []node
+}
+
+// Returns a new template.
+func New(format string) (*T, error) {
+	var b bytes.Buffer
+	state := sLiteral
+	var nodes []node
+
+	for i := 0; i < len(format); i++ {
+		c := format[i]
+		switch state {
+		case sLiteral:
+			switch c {
+			case '{':
+				nodes = append(nodes, node{
+					literal: b.String(),
+				})
+				b.Reset()
+				state = sVariable
+			default:
+				b.WriteByte(c)
+			}
+		case sVariable:
+			switch c {
+			case '}':
+				nodes = append(nodes, node{
+					variable: b.String(),
+				})
+				b.Reset()
+				state = sLiteral
+				break
+			default:
+				b.WriteByte(c)
+			}
+		}
+	}
+
+	if state == sVariable {
+		return nil, ErrMissingClosingBrace
+	}
+
+	if b.Len() != 0 {
+		nodes = append(nodes, node{
+			literal: b.String(),
+		})
+	}
+
+	return &T{nodes}, nil
+}
+
+const (
+	sLiteral = iota
+	sVariable
+)
+
+func (t *T) Eval(data string) (string, error) {
+	var b bytes.Buffer
+	for _, n := range t.nodes {
+		b.WriteString(n.Eval(data))
+	}
+	return b.String(), nil
+}
+
+type node struct {
+	variable string
+	literal  string
+}
+
+func (n node) Eval(data string) string {
+	if n.variable == "" {
+		return n.literal
+	}
+
+	return gjson.Get(data, n.variable).String()
+}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,0 +1,155 @@
+package template_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	interpolate "github.com/segmentio/go-interpolate"
+	"github.com/segmentio/nsq_to_redis/template"
+)
+
+func TestNewInvalid(t *testing.T) {
+	testCases := []struct {
+		format string
+	}{
+		{"{"},
+		{"{foo"},
+		{"da:sad{foo"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q", tc.format), func(t *testing.T) {
+			_, err := template.New(tc.format)
+			if err != template.ErrMissingClosingBrace {
+				t.Error("expected New to fail because closing brace was missing but didn't")
+			}
+		})
+	}
+}
+
+func TestValidTemplates(t *testing.T) {
+	testCases := []struct {
+		format   string
+		data     string
+		expected string
+	}{
+		{"}", `{}`, "}"},
+		{"", `{}`, ""},
+		{"foo:bar:baz", `{}`, "foo:bar:baz"},
+		{"foo:{bar}", `{"bar":"baz"}`, "foo:baz"},
+		{"{foo}:{bar}:baz", `{"foo":"f","bar":"b"}`, "f:b:baz"},
+		{"foo:{bar.baz}", `{"bar":{"baz":"b"}}`, "foo:b"},
+		{"stream:{foo}:{bar}", `{"foo":"f","bar":"b"}`, "stream:f:b"},
+		{"stream:project:{projectId}:ingress", `{}`, "stream:project:null:ingress"},
+		{"integration-errors:project:{projectId}:ingress", `{"projectId":"p"}`, "integration-errors:project:p:ingress"},
+		{"stream:project:{projectId}:ingress", `{"projectId":"foo"}`, "stream:project:foo:ingress"},
+		{"stream:persist:{projectId}:ingress", `{"projectId":"foo"}`, "stream:persist:foo:ingress"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q.Eval(`%s`)", tc.format, tc.data), func(t *testing.T) {
+			tmpl, err := template.New(tc.format)
+			if err != nil {
+				t.Error("expected New to not error, but did: %v", err)
+			}
+
+			got, err := tmpl.Eval(tc.data)
+			if err != nil {
+				t.Errorf("expected Eval to not error, but did: %v", err)
+			}
+
+			if got != tc.expected {
+				t.Errorf("expected eval to return %q, but got: %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+var benchmarkData = []byte(`{
+  "anonymousId": "075100b8-0011-4c87-8731-450e5e41858a",
+  "context": {
+    "app": {
+      "build": 175,
+      "name": "Car Loan Calculator",
+      "namespace": "com.boondoggle.autocalc",
+      "version": "1.7.5"
+    },
+    "device": {
+      "adTrackingEnabled": true,
+      "advertisingId": "khisaldas>",
+      "id": "dsadas",
+      "manufacturer": "samsung",
+      "model": "SAMSUNG-SM-G930A",
+      "name": "heroqlteatt",
+      "type": "android"
+    },
+    "library": {
+      "name": "analytics-android",
+      "version": "4.2.4"
+    },
+    "locale": "en-US",
+    "network": {
+      "bluetooth": false,
+      "carrier": "AT&T",
+      "cellular": false,
+      "wifi": true
+    },
+    "os": {
+      "name": "Android",
+      "version": "7.0"
+    },
+    "screen": {
+      "density": 3,
+      "height": 1920,
+      "width": 1080
+    },
+    "timezone": "America/Chicago",
+    "traits": {
+      "anonymousId": "89b2-d-sads-da-sda-d12bdsad"
+    },
+    "userAgent": "Dalvik/2.1.0 (Linux; U; Android 7.0; SAMSUNG-SM-G930A Build/NRD90M)",
+    "ip": "99.185.26.86"
+  },
+  "event": "Application Launched",
+  "integrations": {
+    "Mixpanel": false,
+    "MoEngage": false
+  },
+  "messageId": "ef5b39cc-ad0a-4a80-8b43-18573a2b6b15",
+  "properties": {
+    "event_id": "33e95185-596c-4097-a597-e3cb3282d686",
+    "event_number": 34,
+    "via_analytics_android": "true"
+  },
+  "timestamp": "2017-04-14T21:49:19.549Z",
+  "type": "track",
+  "writeKey": "xNb9e1cMp52JPelx7gvUo5kwR8vPxjcF",
+  "sentAt": "2017-04-14T21:49:18.000Z",
+  "receivedAt": "2017-04-14T21:49:19.549Z",
+  "originalTimestamp": "2017-04-14T16:49:18-0500"
+}`)
+
+func BenchmarkTemplate(b *testing.B) {
+	tmpl, err := template.New("stream:project:{projectId}:ingress")
+	if err != nil {
+		b.Error(err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		tmpl.Eval(string(benchmarkData))
+	}
+}
+
+func BenchmarkInterpolate(b *testing.B) {
+	tmpl, err := interpolate.New("stream:project:{projectId}:ingress")
+	if err != nil {
+		b.Error(err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		var m map[string]interface{}
+		json.Unmarshal(benchmarkData, &m)
+		tmpl.Eval(m)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -135,6 +135,18 @@
 			"revisionTime": "2014-10-07T22:42:35Z"
 		},
 		{
+			"checksumSHA1": "Ntxt39Uh4Bwm20WFS93Xkzzi12E=",
+			"path": "github.com/tidwall/gjson",
+			"revision": "6e0babc7e842e3080bdc53d94084167e2ac8db65",
+			"revisionTime": "2017-04-14T18:13:32Z"
+		},
+		{
+			"checksumSHA1": "qmePMXEDYGwkAfT9QvtMC58JN/E=",
+			"path": "github.com/tidwall/match",
+			"revision": "173748da739a410c5b0b813b956f89ff94730b4c",
+			"revisionTime": "2016-08-30T17:39:30Z"
+		},
+		{
 			"checksumSHA1": "LfLTyk4ox5wH0YL4sD5rcbrVWBw=",
 			"path": "github.com/tj/docopt",
 			"revision": "c8470e45692f168e8b380c5d625327e756d7d0a9",


### PR DESCRIPTION
This is basically #11 but re-introduced now that we have better benchmarks
and tests.

```
 $ benchcmp old-interpolate.txt new-gjson.txt
 benchmark                old ns/op     new ns/op     delta
 Benchmark1handler-8      2526          1800          -28.74%
 Benchmark2Handlers-8     2670          1813          -32.10%
 BenchmarkList-8          68003         65095         -4.28%
 BenchmarkPubSub-8        32610         32462         -0.45%
```