### PR TITLE
Fix CI

### DIFF
--- a/broadcast/broadcast.go
+++ b/broadcast/broadcast.go
@@ -9,7 +9,7 @@ import (
 	"github.com/segmentio/go-log"
 	"github.com/segmentio/go-stats"
 	"github.com/segmentio/nsq_to_redis/ratelimit"
-	"github.com/statsd/client"
+	"github.com/segmentio/statsdclient"
 	"github.com/tidwall/gjson"
 )
 

--- a/broadcast/broadcast_test.go
+++ b/broadcast/broadcast_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/segmentio/go-log"
 	"github.com/segmentio/nsq_to_redis/broadcast/mocks"
 	"github.com/segmentio/nsq_to_redis/ratelimit"
-	statsd "github.com/statsd/client"
+	statsd "github.com/segmentio/statsdclient"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/list/list.go
+++ b/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/segmentio/go-stats"
 	"github.com/segmentio/nsq_to_redis/broadcast"
 	"github.com/segmentio/nsq_to_redis/template"
-	"github.com/statsd/client"
+	"github.com/segmentio/statsdclient"
 )
 
 // Options for List.

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/segmentio/go-log"
 	"github.com/segmentio/nsq_to_redis/broadcast"
 	"github.com/segmentio/nsq_to_redis/broadcast/mocks"
-	statsd "github.com/statsd/client"
+	statsd "github.com/segmentio/statsdclient"
 )
 
 func BenchmarkList(b *testing.B) {

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/segmentio/nsq_to_redis/list"
 	"github.com/segmentio/nsq_to_redis/pubsub"
 	"github.com/segmentio/nsq_to_redis/ratelimit"
-	"github.com/statsd/client"
+	"github.com/segmentio/statsdclient"
 	"github.com/tj/docopt"
 	"github.com/tj/go-gracefully"
 )

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -7,7 +7,7 @@ import (
 	"github.com/segmentio/go-stats"
 	"github.com/segmentio/nsq_to_redis/broadcast"
 	"github.com/segmentio/nsq_to_redis/template"
-	"github.com/statsd/client"
+	"github.com/segmentio/statsdclient"
 )
 
 // Options for PubSub.

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/segmentio/go-log"
 	"github.com/segmentio/nsq_to_redis/broadcast"
 	"github.com/segmentio/nsq_to_redis/broadcast/mocks"
-	statsd "github.com/statsd/client"
+	statsd "github.com/segmentio/statsdclient"
 )
 
 func TestPubSub(t *testing.T) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -129,10 +129,10 @@
 			"revisionTime": "2015-04-11T19:54:18Z"
 		},
 		{
-			"checksumSHA1": "lJAKwbZNsrklhljF9rUDIP3bqBs=",
-			"path": "github.com/statsd/client",
-			"revision": "4d5b8b0f41649f58d6e9e443857bccafe927f3cb",
-			"revisionTime": "2014-10-07T22:42:35Z"
+			"checksumSHA1": "UqnxpFiLan1XEonWFLoF4y0CFsY=",
+			"path": "github.com/segmentio/statsdclient",
+			"revision": "1694aafe4881d04277b5f2c5835cc504ae53dbc1",
+			"revisionTime": "2018-01-09T07:05:06Z"
 		},
 		{
 			"checksumSHA1": "Ntxt39Uh4Bwm20WFS93Xkzzi12E=",
@@ -157,12 +157,6 @@
 			"path": "github.com/tj/go-gracefully",
 			"revision": "005c1d102f1bf3158f9ba29c12d68a73ac15f321",
 			"revisionTime": "2014-12-27T06:10:38Z"
-		},
-		{
-			"checksumSHA1": "jmq1D8SgW9sdJqL3lkaTDGWrz3M=",
-			"path": "github.com/visionmedia/go-debug",
-			"revision": "ff4a55a20a86994118644bbddc6a216da193cc13",
-			"revisionTime": "2014-10-22T19:30:16Z"
 		}
 	],
 	"rootPath": "github.com/segmentio/nsq_to_redis"


### PR DESCRIPTION
CI is failing:
```
==> govendor sync

Username for 'https://github.com': 
command docker run $(env | grep -E '^CIRCLE_|^DOCKER_|^CIRCLECI=|^CI=' | sed 's/^/--env /g' | tr "\\n" " ") --rm --tty --interactive --name go --net host --volume /var/run/docker.sock:/run/docker.sock --volume ${GOPATH%%:*}/src:/go/src --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} segment/golang:latest
 took more than 10 minutes since last output
```

SSH'ing into the job, and attaching the container, we see:
```
ubuntu@box1000:~/nsq_to_redis$ docker ps
CONTAINER ID        IMAGE                   COMMAND                  CREATED             STATUS              PORTS               NAMES
4a15f52c7b0b        segment/golang:latest   "make -f /usr/src/Mak"   3 minutes ago       Up 3 minutes                            go
ubuntu@box1000:~/nsq_to_redis$ docker attach 4a15f52c7b0b

Password for 'https://github.com':
# cd .; git clone https://github.com/visionmedia/go-debug /go/.cache/govendor/github.com/visionmedia/go-debug
Cloning into '/go/.cache/govendor/github.com/visionmedia/go-debug'...
remote: Repository not found.
fatal: Authentication failed for 'https://github.com/visionmedia/go-debug/'
Error: Remotes failed for:
	Failed for "github.com/visionmedia/go-debug" (failed to clone repo): exit status 128

/usr/src/Makefile.golang:117: recipe for target 'govendor.sync' failed
make: *** [govendor.sync] Error 2
```

Edit: Not done yet. Look like `github.com/visionmedia/go-debug`, which doesn't exist anymore, is pulled in by `github.com/statsd/client`

cc @segmentio/schema 
  